### PR TITLE
Fixes several deprecations in Inspec

### DIFF
--- a/controls/configure.rb
+++ b/controls/configure.rb
@@ -2,17 +2,17 @@ title 'Jenkins configuration'
 
 jenkins_home = attribute(
   'jenkins_home',
-  default: '/var/lib/jenkins',
+  value: '/var/lib/jenkins',
   description: 'Jenkins home'
 )
 plugins = attribute(
   'jenkins_plugins',
-  default: [],
+  value: [],
   description: 'Jenkins plugins'
 )
 settings = attribute(
   'jenkins_settings',
-  default: [],
+  value: [],
   description: 'Jenkins settings'
 )
 

--- a/controls/system.rb
+++ b/controls/system.rb
@@ -1,12 +1,12 @@
 title 'system'
 version = attribute(
   'version',
-  default: '2.60.3-1.1',
+  value: '2.60.3-1.1',
   description: 'Jenkins version'
 )
 jenkins_home = attribute(
   'jenkins_home',
-  default: '/var/lib/jenkins',
+  value: '/var/lib/jenkins',
   description: 'Jenkins home'
 )
 control 'system-01' do

--- a/controls/vitals.rb
+++ b/controls/vitals.rb
@@ -1,13 +1,13 @@
 title 'vitals'
 ports = attribute(
   'ports',
-  default: ['8080'],
+  value: ['8080'],
   description: 'Ports that Jenkins listening on'
 )
 
 jenkins_url = attribute(
   'jenkins_url',
-  default: 'http://localhost:8080',
+  value: 'http://localhost:8080',
   description: 'Jenkins URL'
 )
 


### PR DESCRIPTION
While there are no errors, there are a number of deprecation warnings when running Inspec. This fixes all but one - that remaining one doesn't seem to have an alternative, it just complains about being deprecated for compatibility reasons.

At least this cleans up most of the deprecation.